### PR TITLE
fix prepend for LD_LIBRARY_PATH

### DIFF
--- a/source/casual/make/platform/linux.py
+++ b/source/casual/make/platform/linux.py
@@ -42,7 +42,7 @@ def library_directive(libraries):
 def local_library_path(paths=[]):
     ld_library_path = environment.get('LD_LIBRARY_PATH','')
     return {'LD_LIBRARY_PATH': 
-        ld_library_path + ":" + ":".join(paths)
+        ":".join(paths) + ":" + ld_library_path
         }
 
 

--- a/source/casual/make/platform/osx.py
+++ b/source/casual/make/platform/osx.py
@@ -31,7 +31,7 @@ def library_directive(libraries):
 def local_library_path(paths=[]):
     ld_library_path = environment.get('LD_LIBRARY_PATH','')
     return {'LD_LIBRARY_PATH': 
-        ld_library_path + ":" + ":".join(paths)
+        ":".join(paths) + ":" + ld_library_path
         }
 
 


### PR DESCRIPTION
Before we appended new paths to LD_LIBRARY_PATH
which could cause problems with `cmk test` if $CASUAL_HOME/lib were already in the path.