### PR TITLE
Remove use of deprecated python modules

### DIFF
--- a/source/casual/make/entity/recipe.py
+++ b/source/casual/make/entity/recipe.py
@@ -1,8 +1,7 @@
 import pprint
 
-import distutils.file_util
-
 import os
+import shutil
 import time
 import sys
 
@@ -160,6 +159,15 @@ def test(input):
 
 
 def install(input):
+    def copy_file(src, dst):
+        dst_filepath = dst + os.path.basename(src)
+        if os.path.exists(dst_filepath):
+            if os.path.getmtime(dst_filepath) >= os.path.getmtime(src):
+                return (dst_filepath, False)
+        
+        filename = shutil.copy2(src, dst)
+        return (filename, True)
+    
     source = input['source']
     if isinstance(source, str):
         pass
@@ -173,12 +181,10 @@ def install(input):
         path += '/'
     if not state.settings.dry_run():
         try:
-            (filename, copied) = distutils.file_util.copy_file(
-                source, path, update=1, verbose=0)
+            (filename, copied) = copy_file(source, path)
         except:
             os.makedirs(path)
-            (filename, copied) = distutils.file_util.copy_file(
-                source, path, update=1, verbose=0)
+            (filename, copied) = copy_file(source, path)
 
         if copied:
             sys.stdout.write(output.reformat(

--- a/source/casual/make/tools/executor.py
+++ b/source/casual/make/tools/executor.py
@@ -15,8 +15,8 @@ def importCode(file, filename, name, add_to_sys_modules=0):
        by dynamically importing the given code and optionally adds it
        to sys.modules under the given name.
     """
-    import imp
-    module = imp.new_module(name)
+    import types
+    module = types.ModuleType(name)
 
     if add_to_sys_modules:
         import sys


### PR DESCRIPTION
@ahhud I don't know what kind of brach-strategy we have on `casual-make`.  `master` seems to be totally incompatible for some reson.
We should adopt some kind of "release branches"? Could you decide what you want to do, and do it?